### PR TITLE
Simplify composer-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#5](https://github.com/laminas-api-tools/api-tools-asset-manager/pull/5) `AssetInstaller` and `AssetUninstaller` now consume composers `PackageInterface` instead of `PackageEvent` 
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- [#5](https://github.com/laminas-api-tools/api-tools-asset-manager/pull/5) `AssetInstaller` and `AssetUninstaller` now consume composers `PackageInterface` instead of `PackageEvent` 
+- [#5](https://github.com/laminas-api-tools/api-tools-asset-manager/pull/5) `AssetInstaller` and `AssetUninstaller` now consume Composer's `PackageInterface` instead of `PackageEvent`.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
-        "composer/composer": ">=1.0.0-alpha10",
+        "composer/composer": "^1.5",
         "mikey179/vfsstream": "^1.6",
         "phpunit/phpunit": "^5.7.23 || ^6.4.3",
         "squizlabs/php_codesniffer": "^2.6.2"

--- a/src/AssetInstaller.php
+++ b/src/AssetInstaller.php
@@ -9,8 +9,8 @@
 namespace Laminas\ApiTools\AssetManager;
 
 use Composer\Composer;
-use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
 use DirectoryIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -56,16 +56,15 @@ class AssetInstaller
     }
 
     /**
-     * @param PackageEvent $event
+     * @param PackageInterface $package
      */
-    public function __invoke(PackageEvent $event)
+    public function __invoke(PackageInterface $package)
     {
         $publicPath = sprintf('%s/public', $this->projectPath);
         if (! is_dir($publicPath)) {
             return;
         }
 
-        $package = $event->getOperation()->getPackage();
         $installer = $this->composer->getInstallationManager();
         $packagePath = $installer->getInstallPath($package);
 

--- a/src/AssetUninstaller.php
+++ b/src/AssetUninstaller.php
@@ -9,8 +9,8 @@
 namespace Laminas\ApiTools\AssetManager;
 
 use Composer\Composer;
-use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
 use DirectoryIterator;
 
 class AssetUninstaller
@@ -59,9 +59,9 @@ class AssetUninstaller
     }
 
     /**
-     * @param PackageEvent $event
+     * @param PackageInterface $package
      */
-    public function __invoke(PackageEvent $event)
+    public function __invoke(PackageInterface $package)
     {
         $publicPath = sprintf('%s/public', $this->projectPath);
         if (! is_dir($publicPath)) {
@@ -75,7 +75,6 @@ class AssetUninstaller
             return;
         }
 
-        $package = $event->getOperation()->getPackage();
         $installer = $this->composer->getInstallationManager();
         $packagePath = $installer->getInstallPath($package);
 

--- a/test/AssetInstallerTest.php
+++ b/test/AssetInstallerTest.php
@@ -33,6 +33,21 @@ class AssetInstallerTest extends TestCase
         'api-tools-foobar/styles/styles.css',
     ];
 
+    /**
+     * @var PackageInterface|\Prophecy\Prophecy\ObjectProphecy
+     */
+    private $package;
+
+    /**
+     * @var IOInterface|\Prophecy\Prophecy\ObjectProphecy
+     */
+    private $io;
+
+    /**
+     * @var \org\bovigo\vfs\vfsStreamDirectory
+     */
+    private $filesystem;
+
     public function setUp()
     {
         // Create virtual filesystem
@@ -53,18 +68,6 @@ class AssetInstallerTest extends TestCase
         $composer
             ->getInstallationManager()
             ->will([$installationManager, 'reveal'])
-            ->shouldBeCalled();
-
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation
-            ->getPackage()
-            ->will([$this->package, 'reveal'])
-            ->shouldBeCalled();
-
-        $this->event = $this->prophesize(PackageEvent::class);
-        $this->event
-            ->getOperation()
-            ->will([$operation, 'reveal'])
             ->shouldBeCalled();
 
         $this->io = $this->prophesize(IOInterface::class);
@@ -100,10 +103,9 @@ class AssetInstallerTest extends TestCase
         );
         $installer->setProjectPath(vfsStream::url('project'));
 
-        $event = $this->prophesize(PackageEvent::class);
-        $event->getOperation()->shouldNotBeCalled();
+        $package = $this->prophesize(PackageInterface::class);
 
-        $this->assertNull($installer($event->reveal()));
+        $this->assertNull($installer($package->reveal()));
     }
 
     public function testInstallerAbortsIfPackageDoesNotHaveConfiguration()
@@ -113,7 +115,7 @@ class AssetInstallerTest extends TestCase
         $installer = $this->createInstaller();
         $installer->setProjectPath(vfsStream::url('project'));
 
-        $this->assertNull($installer($this->event->reveal()));
+        $this->assertNull($installer($this->package->reveal()));
 
         foreach ($this->expectedAssets as $asset) {
             $path = vfsStream::url('project/public/' . $asset);
@@ -132,7 +134,7 @@ class AssetInstallerTest extends TestCase
         $installer = $this->createInstaller();
         $installer->setProjectPath(vfsStream::url('project'));
 
-        $this->assertNull($installer($this->event->reveal()));
+        $this->assertNull($installer($this->package->reveal()));
 
         foreach ($this->expectedAssets as $asset) {
             $path = vfsStream::url('project/public/' . $asset);
@@ -151,7 +153,7 @@ class AssetInstallerTest extends TestCase
         $installer = $this->createInstaller();
         $installer->setProjectPath(vfsStream::url('project'));
 
-        $this->assertNull($installer($this->event->reveal()));
+        $this->assertNull($installer($this->package->reveal()));
 
         foreach ($this->expectedAssets as $asset) {
             $path = vfsStream::url('project/public/' . $asset);
@@ -170,7 +172,7 @@ class AssetInstallerTest extends TestCase
         $installer = $this->createInstaller();
         $installer->setProjectPath(vfsStream::url('project'));
 
-        $this->assertNull($installer($this->event->reveal()));
+        $this->assertNull($installer($this->package->reveal()));
 
         $gitIgnoreFile = vfsStream::url('project/public/.gitignore');
         $this->assertFileExists($gitIgnoreFile, 'public/.gitignore was not created');
@@ -205,7 +207,7 @@ class AssetInstallerTest extends TestCase
         $installer = $this->createInstaller();
         $installer->setProjectPath(vfsStream::url('project'));
 
-        $this->assertNull($installer($this->event->reveal()));
+        $this->assertNull($installer($this->package->reveal()));
 
         $gitIgnoreContents = file_get_contents($gitIgnoreFile);
         $gitIgnoreContents = explode("\n", $gitIgnoreContents);
@@ -241,7 +243,7 @@ class AssetInstallerTest extends TestCase
             )
             ->shouldBeCalled();
 
-        $this->assertNull($installer($this->event->reveal()));
+        $this->assertNull($installer($this->package->reveal()));
 
         foreach ($this->expectedAssets as $asset) {
             $path = vfsStream::url('project/public/' . $asset);
@@ -283,7 +285,7 @@ class AssetInstallerTest extends TestCase
             ->writeError(Argument::any())
             ->shouldNotBeCalled();
 
-        $this->assertNull($installer($this->event->reveal()));
+        $this->assertNull($installer($this->package->reveal()));
 
         foreach ($this->expectedAssets as $asset) {
             $path = vfsStream::url('project/public/' . $asset);
@@ -306,7 +308,7 @@ class AssetInstallerTest extends TestCase
             ->writeError(Argument::any())
             ->shouldNotBeCalled();
 
-        $this->assertNull($installer($this->event->reveal()));
+        $this->assertNull($installer($this->package->reveal()));
 
         foreach ($this->expectedAssets as $asset) {
             $path = vfsStream::url('project/public/' . $asset);

--- a/test/AssetUninstallerTest.php
+++ b/test/AssetUninstallerTest.php
@@ -71,6 +71,21 @@ class AssetUninstallerTest extends TestCase
         ],
     ];
 
+    /**
+     * @var \org\bovigo\vfs\vfsStreamDirectory
+     */
+    private $filesystem;
+
+    /**
+     * @var PackageInterface|\Prophecy\Prophecy\ObjectProphecy
+     */
+    private $package;
+
+    /**
+     * @var IOInterface|\Prophecy\Prophecy\ObjectProphecy
+     */
+    private $io;
+
     public function setUp()
     {
         // Create virtual filesystem
@@ -98,18 +113,6 @@ class AssetUninstallerTest extends TestCase
         $composer
             ->getInstallationManager()
             ->will([$installationManager, 'reveal'])
-            ->shouldBeCalled();
-
-        $operation = $this->prophesize(UninstallOperation::class);
-        $operation
-            ->getPackage()
-            ->will([$this->package, 'reveal'])
-            ->shouldBeCalled();
-
-        $this->event = $this->prophesize(PackageEvent::class);
-        $this->event
-            ->getOperation()
-            ->will([$operation, 'reveal'])
             ->shouldBeCalled();
 
         $this->io = $this->prophesize(IOInterface::class);
@@ -145,10 +148,8 @@ class AssetUninstallerTest extends TestCase
         );
         $uninstaller->setProjectPath(vfsStream::url('project'));
 
-        $event = $this->prophesize(PackageEvent::class);
-        $event->getOperation()->shouldNotBeCalled();
-
-        $this->assertNull($uninstaller($event->reveal()));
+        $package = $this->prophesize(PackageInterface::class);
+        $this->assertNull($uninstaller($package->reveal()));
     }
 
     public function testUninstallerAbortsIfNoPublicGitignoreFileFound()
@@ -164,10 +165,9 @@ class AssetUninstallerTest extends TestCase
         );
         $uninstaller->setProjectPath(vfsStream::url('project'));
 
-        $event = $this->prophesize(PackageEvent::class);
-        $event->getOperation()->shouldNotBeCalled();
+        $package = $this->prophesize(PackageInterface::class);
 
-        $this->assertNull($uninstaller($event->reveal()));
+        $this->assertNull($uninstaller($package->reveal()));
     }
 
     public function testUninstallerAbortsIfPackageDoesNotHaveConfiguration()
@@ -178,7 +178,7 @@ class AssetUninstallerTest extends TestCase
         $uninstaller = $this->createUninstaller();
         $uninstaller->setProjectPath(vfsStream::url('project'));
 
-        $this->assertNull($uninstaller($this->event->reveal()));
+        $this->assertNull($uninstaller($this->package->reveal()));
 
         foreach ($this->installedAssets as $asset) {
             $path = vfsStream::url('project/', $asset);
@@ -198,7 +198,7 @@ class AssetUninstallerTest extends TestCase
         $uninstaller = $this->createUninstaller();
         $uninstaller->setProjectPath(vfsStream::url('project'));
 
-        $this->assertNull($uninstaller($this->event->reveal()));
+        $this->assertNull($uninstaller($this->package->reveal()));
 
         foreach ($this->installedAssets as $asset) {
             $path = vfsStream::url('project/', $asset);
@@ -225,7 +225,7 @@ class AssetUninstallerTest extends TestCase
             $gitignore
         );
 
-        $this->assertNull($uninstaller($this->event->reveal()));
+        $this->assertNull($uninstaller($this->package->reveal()));
 
         $test = file_get_contents(vfsStream::url('project/public/.gitignore'));
         $this->assertEquals($gitignore, $test);
@@ -251,7 +251,7 @@ class AssetUninstallerTest extends TestCase
             $gitignore
         );
 
-        $this->assertNull($uninstaller($this->event->reveal()));
+        $this->assertNull($uninstaller($this->package->reveal()));
 
         foreach ($this->installedAssets as $asset) {
             $path = sprintf('%s/%s', vfsStream::url('project'), $asset);
@@ -282,7 +282,7 @@ class AssetUninstallerTest extends TestCase
             $gitignore
         );
 
-        $this->assertNull($uninstaller($this->event->reveal()));
+        $this->assertNull($uninstaller($this->package->reveal()));
 
         foreach ($this->installedAssets as $asset) {
             $path = sprintf('%s/%s', vfsStream::url('project'), $asset);
@@ -337,7 +337,7 @@ class AssetUninstallerTest extends TestCase
             )
             ->shouldBeCalled();
 
-        $this->assertNull($uninstaller($this->event->reveal()));
+        $this->assertNull($uninstaller($this->package->reveal()));
 
         foreach ($this->installedAssets as $asset) {
             $path = vfsStream::url('project/', $asset);
@@ -375,7 +375,7 @@ class AssetUninstallerTest extends TestCase
         $uninstaller = $this->createUninstaller();
         $uninstaller->setProjectPath(vfsStream::url('project'));
 
-        $this->assertNull($uninstaller($this->event->reveal()));
+        $this->assertNull($uninstaller($this->package->reveal()));
 
         foreach ($this->installedAssets as $asset) {
             $path = vfsStream::url('project/', $asset);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Due to the complexity level which is needed to migrate to composer v2 in #3, I would like to propose this simplified version of this plugin.

It does the same as before. Due to the removal of the hole `PackageEvent` stuff, we do not have to create composer version specific unit tests in #3 and so on.

What do you think?