### PR TITLE
Provide proper interface for migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#7](https://github.com/laminas-api-tools/api-tools-asset-manager/pull/7) Fixes issues during migration from 1.2.0
 
 ## 1.3.0 - 2020-07-01
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

This will resolve issues with migrations where the `vendor/` directory contains the old version while upgrading to 1.3.0

Fixes #6 
