### PR TITLE
Missing  Introduction section name and fix glitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # api-tools-asset-manager
 
 [![Build Status](https://github.com/laminas-api-tools/api-tools-asset-manager/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/laminas-api-tools/api-tools-asset-manager/actions/workflows/continuous-integration.yml)
-``
+
+## Introduction
+
 api-tools-asset-manager is a composer plugin that will copy configured web-accessible
 assets into the public document root of your Laminas application. It uses
 the configuration format of [rwoverdijk/AssetManager](https://github.com/rwoverdijk/AssetManager),


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

Added missing `Introduction` and fixed broken section between Build status and description